### PR TITLE
Add teams and scouts to the state

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "sass-loader": "^7.0.3",
     "source-map-loader": "^0.2.3",
     "style-loader": "^0.21.0",
-    "ts-loader": "^4.4.2",
-    "typescript": "^2.9.2",
+    "ts-loader": "^5.2.2",
+    "typescript": "^3.1.3",
     "webpack": "^4.17.2",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.1.5"

--- a/src/processing/addTeams.ts
+++ b/src/processing/addTeams.ts
@@ -1,0 +1,12 @@
+import { addTeams } from "./scoutDataFormatter"
+// TODO: JSON importinng through UI
+import * as data from './scout.json'
+import { store } from '../state/store'
+
+// TODO: Maybe make changing this possible through the UI
+const preferences = {
+    gameName : "frc2018powerup"
+}
+
+addTeams(data["teams"], preferences.gameName)
+

--- a/src/processing/scoutDataFormatter.ts
+++ b/src/processing/scoutDataFormatter.ts
@@ -1,0 +1,58 @@
+import { addTeam, addScout } from '../state/actions'
+import { store } from '../state/store'
+import { ScoutSections } from '../data/scout'
+
+// Takes one object of raw scout data from one match. Will return a formatted object of the same data
+function formatScout(scoutData: object, gameName:string) {
+    const scoutMetrics = (scoutData as any)["metrics"]
+
+    // Initialize object to store the formatted scout data
+    var formattedMetrics: ScoutSections = {}
+
+    // Finds all the different sections in the scout data and stores them in an array
+    var allScoutSections: Array<string> = []
+    for (var metric in scoutMetrics) {
+        if (!allScoutSections.includes(scoutMetrics[metric]["category"])){
+            allScoutSections.push(scoutMetrics[metric]["category"])
+        }
+    }
+
+    // Add in the metrics object within each scout section
+    for (var section in allScoutSections){
+        formattedMetrics[allScoutSections[section]] = {metrics: {}}
+    }
+
+    // Format the individual metrics and organizes them to be in their correct section
+    for (var metric in scoutMetrics) {
+        for (var section in allScoutSections){
+            // Puts the metric in its correct section
+            if (scoutMetrics[metric]["category"] == allScoutSections[section]){
+                formattedMetrics[allScoutSections[section]].metrics[scoutMetrics[metric]["name"]] = 
+                    ({type: scoutMetrics[metric]["type"], value: scoutMetrics[metric]["value"]})
+            }
+        }
+    }
+
+    return {
+        gameName: gameName, 
+        sections: formattedMetrics
+    }
+
+}
+
+// Add teams and their scouts to the state
+// TODO: Use TBA to include team name in state instead of team number
+export function addTeams(allTeams: object, gameName:string) {
+    for (var team in allTeams) {
+        // Add team to the state and creates the scouts object within the object
+        store.dispatch(addTeam(team, Number(team), {}))
+        // Format and associate each scout with its team
+        for (var scout in (allTeams as any)[team]) {
+            store.dispatch(addScout(Number(team),
+                            (allTeams as any)[team][Number(scout)]["name"],
+                            formatScout((allTeams as any)[team][Number(scout)], gameName))
+            )
+        }
+    
+    }
+}

--- a/src/state/actions.ts
+++ b/src/state/actions.ts
@@ -8,6 +8,6 @@ export const enum ActionTypes {
     ADD_GAME = 'ADD_GAME'
 }
 
-export const addTeam = (name: string, number: number, scouts: Scouts = {}) => action(ActionTypes.ADD_TEAM, { name, number, scouts });
+export const addTeam = (name: string, teamNumber: number, scouts: Scouts = {}) => action(ActionTypes.ADD_TEAM, { name, teamNumber, scouts });
 export const addScout = (teamNumber: number, scoutName: string, scout: Scout) => action(ActionTypes.ADD_SCOUT, { teamNumber, scoutName, scout });
 export const addGame = (name: string, metrics: Metrics) => action(ActionTypes.ADD_GAME, { name, metrics });

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -8,7 +8,7 @@ import * as actions from './actions';
 const teams = (state: Teams = {}, action: ActionType<typeof actions>) => {
     switch (action.type) {
         case ActionTypes.ADD_TEAM: {
-            return { ...state, [action.payload.name]: { number: action.payload.number, scouts: action.payload.scouts }}
+            return { ...state, [action.payload.teamNumber]: { name: action.payload.name, scouts: action.payload.scouts }}
         }
         case ActionTypes.ADD_SCOUT: {
             return {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "noImplicitAny": true,
     "module": "commonjs",
     "target": "es5",
-    "jsx": "react"
+    "jsx": "react",
+    "resolveJsonModule": true
   },
   "include": [
     "./src/**/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,9 @@
     "sourceMap": true,
     "noImplicitAny": true,
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2016",
     "jsx": "react",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
One very minor issue:

If there are two scouts for a team on the same qualification match, only one of the scouts will be preserved in the state. 

Personally, I don't think it's very necessary to modify the design of our state to resolve this issue as we shouldn't be having two scouts on the same team during a match. Even if we did want two scouts on a team for some reason, we could just view that data on Robot Scouter because I'm not sure how helpful that data would be for analytics purposes.